### PR TITLE
Improve organization profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,36 @@
-<img src="https://raw.githubusercontent.com/cncf/artwork/refs/heads/main/projects/tekton/horizontal/color/tekton-horizontal-color.svg" alt="Tekton logo" width="300"/>
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/cncf/artwork/refs/heads/main/projects/tekton/horizontal/white/tekton-horizontal-white.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/cncf/artwork/refs/heads/main/projects/tekton/horizontal/color/tekton-horizontal-color.svg">
+  <img alt="Tekton logo" src="https://raw.githubusercontent.com/cncf/artwork/refs/heads/main/projects/tekton/horizontal/color/tekton-horizontal-color.svg" width="300">
+</picture>
 
-Cloud Native CI/CD
+**A cloud-native, open-source framework for creating CI/CD systems.**
+Tekton lets you build, test, and deploy across any cloud provider or on-premises system using Kubernetes-native pipelines.
 
-Learn more at https://tekton.dev/
+<p>
+  <a href="https://tekton.dev/docs/">Learn More 📚</a> ·
+  <a href="https://tekton.dev/docs/getting-started/">Get Started 🚀</a> ·
+  <a href="https://github.com/tektoncd/community">Contribute 🤝</a> ·
+  <a href="https://tekton.dev/docs/pipelines/">API Reference 📖</a>
+</p>
+
+---
+
+**Core projects:** [Pipeline](https://github.com/tektoncd/pipeline) · [Chains](https://github.com/tektoncd/chains) · [Triggers](https://github.com/tektoncd/triggers) · [CLI](https://github.com/tektoncd/cli) · [Dashboard](https://github.com/tektoncd/dashboard) — [see all repositories →](https://github.com/orgs/tektoncd/repositories)
+
+### 👋 Getting Involved
+
+Join the community! We're friendly and always looking for contributors.
+
+- 💬 [Slack](https://tektoncd.slack.com/) — [join here](https://join.slack.com/t/tektoncd/shared_invite/zt-1z8ctzsyv-wLXWwA2Rl3AOhcNGqpWRUw)
+- 📧 [Mailing list](https://groups.google.com/forum/#!forum/tekton-dev)
+- 📅 [Working group meetings](https://github.com/tektoncd/community/blob/main/working-groups.md)
+- 🪜 [Contributor ladder](https://github.com/tektoncd/community/blob/main/process/contributor-ladder.md)
+
+### 🦺 Security
+
+Please report security vulnerabilities through our [security policy](https://github.com/tektoncd/.github/blob/main/SECURITY.md).
+
+---
+
+Tekton is a [CNCF](https://cncf.io/) incubating project.


### PR DESCRIPTION
## What

Overhaul the GitHub organization profile README to be more informative and welcoming.

## Why

The current profile is minimal — just a logo, a tagline ("Cloud Native CI/CD"), and a link to tekton.dev. Compared to other CNCF projects like OpenTelemetry and Sigstore, we're missing an opportunity to help newcomers understand what Tekton is and how to get involved.

## What changed

- **Dark/light mode logo** using `<picture>` element (like Sigstore)
- **Descriptive paragraph** explaining what Tekton actually does
- **Quick action links** — Learn More, Get Started, Contribute, API Reference (inspired by OpenTelemetry)
- **Key repositories table** — highlights Pipeline, Chains, Triggers, CLI, Dashboard, Operator, and Catalog for easy navigation
- **Getting involved section** — surfaces Slack, mailing list, working groups, and contributor ladder
- **Security policy link**
- **CNCF graduation status**

## References

Inspired by:
- [OpenTelemetry org profile](https://github.com/open-telemetry)
- [Sigstore org profile](https://github.com/sigstore)