### PR TITLE
docs: link security threat model in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,10 @@ fixes are backported to all supported LTS releases. See the
 [Tekton support policy](https://github.com/tektoncd/community/blob/main/releases.md#support-policy)
 for details.
 
+## Threat Model
+
+For a detailed overview of our security architecture, trust boundaries, and potential threats, please refer to the [Tekton Security Threat Model](https://github.com/tektoncd/pipeline/blob/main/docs/security-threat-model.md).
+
 ## Reporting a Vulnerability
 
 **Please do not report security vulnerabilities through public GitHub issues.**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,9 @@ for details.
 
 ## Threat Model
 
-For a detailed overview of our security architecture, trust boundaries, and potential threats, please refer to the [Tekton Security Threat Model](https://github.com/tektoncd/pipeline/blob/main/docs/security-threat-model.md).
+For a detailed overview of our security architecture, trust boundaries, and potential threats, please refer to the specific Threat Model for each project:
+
+* **Tekton Pipeline:** [Pipeline Security Threat Model](https://github.com/tektoncd/pipeline/blob/main/docs/security-threat-model.md)
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
This adds a link to the newly created Security Threat Model introduced in tektoncd/pipeline#10313